### PR TITLE
FIX: adb_pairing.py

### DIFF
--- a/device_manager/connection/adb_pairing.py
+++ b/device_manager/connection/adb_pairing.py
@@ -337,6 +337,9 @@ class AdbPairing:
             else:
                 all_ops.append(False)
 
+        if len(all_ops) == 0:
+            return False
+
         return all(all_ops)
 
     def stop_pair_listener(self) -> None:

--- a/device_manager/connection/utils/mdns_listener.py
+++ b/device_manager/connection/utils/mdns_listener.py
@@ -48,7 +48,7 @@ class MDnsListener(ServiceListener):
             extract the serial number from the service name. Defaults to None.
         service_type (str, optional): The service type to filter the services
             found by the mDNS listener. Defaults to
-            "_adb-tls-pairing._tcp.local.".
+                "_adb-tls-pairing._tcp.local.".
 
     methods:
         update_service: Updates the service information in the service context.
@@ -121,6 +121,8 @@ class MDnsListener(ServiceListener):
         Returns:
             Optional[ServiceInfo]: The extracted service information.
         """
+        if info is None:
+            return None
         try:
             ip = f'{socket.inet_ntoa(info.addresses[0])}'
             port = info.port
@@ -133,7 +135,10 @@ class MDnsListener(ServiceListener):
                 serial_num = match_result.group(1)
                 return ServiceInfo(serial_num, ip, port)
             else:
-                logger.warning(f'AdbMDns not match: {info.name}')
+                logger.warning(
+                    f'AdbMDns not match: {info.name}',
+                    extra={'info': info},
+                )
         except Exception as e:  # pragma: no cover
             logger.error(e)
             raise e

--- a/device_manager/manager.py
+++ b/device_manager/manager.py
@@ -70,7 +70,6 @@ class DeviceManager:
         self,
         subprocess_check_flag: bool = False,
         fixed_port: int = DEFAULT_FIXED_PORT,
-        check_adb_versions: bool = True,
     ):
         self.subprocess_check = subprocess_check_flag
         self._devices_fixed_port = fixed_port


### PR DESCRIPTION
pair_devices -> if all_ops is a empty list return False.