### PR TITLE
Add capture_output parameter to adb command execution

### DIFF
--- a/device_manager/manager.py
+++ b/device_manager/manager.py
@@ -275,6 +275,7 @@ class DeviceManager:
         command: str,
         comm_uris: Optional[List[str]] = None,
         subprocess_check_flag: bool = False,
+        capture_output: bool = False,
         **kwargs,
     ) -> CompletedProcess:
         """Executes a custom adb command on all connected devices.
@@ -300,6 +301,8 @@ class DeviceManager:
                 subprocess execution was successful, passed to the subprocess
                 `check` argument. Defaults to False.
                 Check the subprocess documentation for more information.
+            capture_output (bool, optional): A flag to capture the output of
+                the command. Defaults to False.
             **kwargs: Additional arguments to be added to the command.
 
         Returns:
@@ -328,6 +331,8 @@ class DeviceManager:
             adb_command,
             shell=True,
             check=subprocess_check_flag,
+            capture_output=capture_output,
+            text=capture_output if capture_output else None,
         )
 
     def adb_pairing_instance(


### PR DESCRIPTION
This pull request introduces a new feature to the `execute_adb_command` method in `device_manager/manager.py` by adding a `capture_output` parameter. This enhancement allows for optional capturing of the output from the executed ADB command.

### Enhancements to `execute_adb_command`:

* Added a new `capture_output` parameter to the method signature, enabling users to specify whether the output of the ADB command should be captured. Defaults to `False`. (`[[1]](diffhunk://#diff-090919d30763266dacc63bfce7f8f58699dbb393045695d247011f84139100a0R278)`, `[[2]](diffhunk://#diff-090919d30763266dacc63bfce7f8f58699dbb393045695d247011f84139100a0R304-R305)`)
* Updated the `subprocess.run` call to include the `capture_output` parameter and conditionally set the `text` argument when `capture_output` is enabled. (`[device_manager/manager.pyR334-R335](diffhunk://#diff-090919d30763266dacc63bfce7f8f58699dbb393045695d247011f84139100a0R334-R335)`)