### PR TITLE
Add file transfer methods for local and device interaction

### DIFF
--- a/device_manager/device_actions.py
+++ b/device_manager/device_actions.py
@@ -329,3 +329,51 @@ class DeviceActions:
                 ],
                 check=self.subprocess_check_flag,
             )
+
+    def push_file(
+        self,
+        local_path: str,
+        remote_path: str,
+    ) -> None:
+        """Pushes a file from the local machine to the device.
+
+        Args:
+            local_path (str): The path to the file on the local machine.
+            remote_path (str): The destination path on the device.
+        """
+        if self.validate_connection():
+            subprocess.run(
+                [
+                    'adb',
+                    '-s',
+                    self.current_comm_uri,
+                    'push',
+                    local_path,
+                    remote_path,
+                ],
+                check=self.subprocess_check_flag,
+            )
+
+    def pull_file(
+        self,
+        remote_path: str,
+        local_path: str,
+    ) -> None:
+        """Pulls a file from the device to the local machine.
+
+        Args:
+            remote_path (str): The path to the file on the device.
+            local_path (str): The destination path on the local machine.
+        """
+        if self.validate_connection():
+            subprocess.run(
+                [
+                    'adb',
+                    '-s',
+                    self.current_comm_uri,
+                    'pull',
+                    remote_path,
+                    local_path,
+                ],
+                check=self.subprocess_check_flag,
+            )


### PR DESCRIPTION
This pull request introduces two new methods, `push_file` and `pull_file`, to the `device_manager/device_actions.py` file. These methods provide functionality for transferring files between the local machine and a connected device using ADB (Android Debug Bridge).

### New file transfer functionality:

* Added `push_file` method: This method allows pushing a file from the local machine to the connected device. It validates the device connection before executing the ADB `push` command.
* Added `pull_file` method: This method enables pulling a file from the connected device to the local machine. It also validates the device connection before running the ADB `pull` command.