### PR TITLE
[SAF-99] fix: use serial_numbers instead serial_number in execute_adb_command

### DIFF
--- a/device_manager/actions/camera_actions.py
+++ b/device_manager/actions/camera_actions.py
@@ -23,7 +23,7 @@ class CameraActions:
         if self.validate_connection_callback():
             execute_adb_command(
                 command=f'am start -a {CameraIntents.ACTION_STILL_IMAGE_CAMERA}',  # noqa: E501
-                serial_number=[self.serial_number],
+                serial_numbers=[self.serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
             )
@@ -37,7 +37,7 @@ class CameraActions:
         if self.validate_connection_callback():
             execute_adb_command(
                 command=f'am start -a {CameraIntents.ACTION_VIDEO_CAMERA}',
-                serial_number=[self.serial_number],
+                serial_numbers=[self.serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
             )
@@ -51,7 +51,7 @@ class CameraActions:
         if self.validate_connection_callback():
             execute_adb_command(
                 command='am force-stop com.android.camera',
-                serial_number=[self.serial_number],
+                serial_numbers=[self.serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
             )
@@ -65,7 +65,7 @@ class CameraActions:
         if self.validate_connection_callback():
             result = execute_adb_command(
                 command=f'cmd package resolve-activity --brief -a {CameraIntents.ACTION_IMAGE_CAPTURE}',  # noqa: E501
-                serial_number=[self.serial_number],
+                serial_numbers=[self.serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
                 capture_output=True,
@@ -83,7 +83,7 @@ class CameraActions:
         if self.validate_connection_callback():
             execute_adb_command(
                 command=f'input keyevent {ADBKeyEvent.KEYCODE_ENTER.value}',
-                serial_number=[self.serial_number],
+                serial_numbers=[self.serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
             )
@@ -97,7 +97,7 @@ class CameraActions:
         if self.validate_connection_callback():
             execute_adb_command(
                 command='rm -rf /sdcard/DCIM/Camera/*',
-                serial_number=[self.serial_number],
+                serial_numbers=[self.serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
             )
@@ -135,7 +135,7 @@ class CameraActions:
             if self.validate_connection_callback():
                 result = execute_adb_command(
                     command='ls -t /sdcard/DCIM/Camera',
-                    serial_number=[self.serial_number],
+                    serial_numbers=[self.serial_number],
                     shell=True,
                     subprocess_check_flag=self.subprocess_check_flag,
                     capture_output=True,
@@ -145,7 +145,7 @@ class CameraActions:
                 for file in files:
                     execute_adb_command(
                         command=f'pull /sdcard/DCIM/Camera/{file} {destination.resolve()}',  # noqa: E501
-                        serial_number=[self.serial_number],
+                        serial_numbers=[self.serial_number],
                         subprocess_check_flag=self.subprocess_check_flag,
                     )
             else:

--- a/device_manager/infos/app.py
+++ b/device_manager/infos/app.py
@@ -26,7 +26,7 @@ class AppInfo:
         ):
             self.dumpsys = execute_adb_command(
                 command=f'dumpsys package {self.package}',
-                serial_number=self.__serial_number,
+                serial_numbers=[self.__serial_number],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,
                 capture_output=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "device_manager"
-version = "2.0.0"
+version = "2.0.1"
 description = "Version using just usb connection "
 authors = [
     { name = "Bruno Pinheiro", email = "bruno.opinheiro@outlook.com" },


### PR DESCRIPTION

Fixed a TypeError caused by a naming inconsistency in execute_adb_command. The function definition required the plural argument serial_numbers, but several internal calls were passing the singular serial_number.

Key Changes
Parameter Standardization: Updated all calls in camera_actions.py and app.py to use serial_numbers.

Bug Fixed
Error: TypeError: execute_adb_command() missing 1 required positional argument: 'serial_numbers'