### PR TITLE
REFECTOR: screen_shot functionality has a destionation parameter now

### DIFF
--- a/device_manager/device_actions.py
+++ b/device_manager/device_actions.py
@@ -295,12 +295,12 @@ class DeviceActions:
                 subprocess_check_flag=self.subprocess_check_flag,
             )
     
-    def screen_shot(self, image_name: str = "screen") -> None:
+    def screen_shot(self, image_name: str = "screen", destination: str = '/sdcard') -> None:
         """Takes a screenshot of the device screen.
         """
         if self.validate_connection():
             execute_adb_command(
-                command=f'screencap -p /sdcard/{image_name}.png',
+                command=f'screencap -p {destination}/{image_name}.png',
                 comm_uris=[self.current_comm_uri],
                 shell=True,
                 subprocess_check_flag=self.subprocess_check_flag,


### PR DESCRIPTION
This pull request introduces a small but useful enhancement to the `screen_shot` method in the `device_manager/device_actions.py` file, allowing users to specify a custom destination directory for screenshots.

- Added a `destination` parameter (defaulting to `/sdcard`) to the `screen_shot` method, enabling screenshots to be saved to a user-defined directory instead of being hardcoded to `/sdcard`.